### PR TITLE
Help with LDAP parameter translation

### DIFF
--- a/iam-keycloak-migration.sh
+++ b/iam-keycloak-migration.sh
@@ -323,24 +323,40 @@ function inspectIdpConnections {
       echo "[$migrated] Migrate $ldapName"
       echo "$ldapConnection" | jq -r '
       (.LDAP_USERIDMAP | sub("^\\*:"; "")) as $user_attribute |
-      (.LDAP_USERFILTER | [ scan("objectclass=([^)]+)") | .[0] ] | join(",")) as $object_classes |
+      (.LDAP_GROUPIDMAP | sub("^\\*:"; "")) as $group_attribute |
+      (.LDAP_USERFILTER | [ scan("objectclass=([^)]+)") | .[0] ] | join(",")) as $user_object_classes |
+      (.LDAP_GROUPMEMBERIDMAP | split(":")) as [$group_object_class, $membership_ldap_attribute] |
       (if .LDAP_NESTEDSEARCH | test("true") then "Subtree" else "One Level" end) as $search_scope |
       (if .LDAP_PAGINGSEARCH | test("true") then "Yes" else "No" end) as $pagination |
-"    Connection name: " + .LDAP_ID + "
-    Connection URL: " + .LDAP_URL + "
-    Enable StartTLS: No
-    Bind type: simple
-    Bind DN: " + .LDAP_BINDDN + "
-    Bind credentials: <bind password>
-    Edit mode: READ_ONLY
-    Users DN: " + .LDAP_BASEDN + "
-    Username LDAP attribute: " + $user_attribute + "
-    RDN LDAP attribute: " + $user_attribute + "
-    UUID LDAP attribute: " + $user_attribute + "
-    User object classes: " + $object_classes + "
-    User LDAP filter: \"\" (Can be used to select a subset of LDAP users to federate)
-    Search scope: " + $search_scope + "
-    Pagination: " + $pagination'
+"    - Connection name: " + .LDAP_ID + "
+    - Connection URL: " + .LDAP_URL + "
+    - Enable StartTLS: No
+    - Bind type: simple
+    - Bind DN: " + .LDAP_BINDDN + "
+    - Bind credentials: <bind password>
+    - Edit mode: READ_ONLY
+    - Users DN: " + .LDAP_BASEDN + "
+    - Username LDAP attribute: " + $user_attribute + "
+    - RDN LDAP attribute: " + $user_attribute + "
+    - UUID LDAP attribute: " + $user_attribute + "
+    - User object classes: " + $user_object_classes + "
+    - User LDAP filter: \"\" (Can be used to select a subset of LDAP users to federate)
+    - Search scope: " + $search_scope + "
+    - Pagination: " + $pagination + "
+    - Group mapper: (to import LDAP groups to Keycloak)
+      - Name: groups
+      - Mapper type: group-ldap-mapper
+      - LDAP Groups DN: " + .LDAP_BASEDN + "
+      - Group Name LDAP Attribute: " + $group_attribute + "
+      - Group Object classes: " + $group_object_class + "
+      - Membership LDAP Attribute: " + $membership_ldap_attribute + "
+      - Membership Attribute Type: DN
+      - Membership User LDAP Attribute: (Unused)
+      - LDAP Filter: \"\" (Can be used to select a subset of LDAP groups to federate),
+      - Mode: READ_ONLY
+      - User Groups Retrieve Strategy: LOAD_GROUPS_BY_MEMBER_ATTRIBUTE
+      - Member-Of LDAP Attribute: (Unused)
+      - Mapped Group Attributes: \"\" (Can be used to load LDAP attributes into Keycloak)"'
     done
   fi
 

--- a/iam-keycloak-migration.sh
+++ b/iam-keycloak-migration.sh
@@ -328,7 +328,8 @@ function inspectIdpConnections {
       (.LDAP_GROUPMEMBERIDMAP | split(":")) as [$group_object_class, $membership_ldap_attribute] |
       (if .LDAP_NESTEDSEARCH | test("true") then "Subtree" else "One Level" end) as $search_scope |
       (if .LDAP_PAGINGSEARCH | test("true") then "Yes" else "No" end) as $pagination |
-"    - Connection name: " + .LDAP_ID + "
+"    Attributes to use in Keycloak. These attributes are for information only and are not tested by this tool.
+    - Connection name: " + .LDAP_ID + "
     - Connection URL: " + .LDAP_URL + "
     - Enable StartTLS: No
     - Bind type: simple


### PR DESCRIPTION
Output:

```
jammy:iam-to-keycloak-migration$ IAM_NAMESPACE=bedrock3 ./iam-keycloak-migration.sh cp4i

Checking we are logged into a cluster...

Getting login information from the cluster...

Generating Common services access token...

Generating Keycloak access token...

Starting IAM migration helper script...

Checking connections to Common services

Getting IAM teams

Generating checklist...

LDAP connections
================
[x] Migrate jumpcloud-ldap
    Connection name: jumpcloud-ldap
    Connection URL: ldaps://ldap.jumpcloud.com:636
    Enable StartTLS: No
    Bind type: simple
    Bind DN: uid=ldapbind,ou=Users,o=65314a78716d2b0ff3ff816c,dc=jumpcloud,dc=com
    Bind credentials: <bind password>
    Edit mode: READ_ONLY
    Users DN: o=65314a78716d2b0ff3ff816c,dc=jumpcloud,dc=com
    Username LDAP attribute: uid
    RDN LDAP attribute: uid
    UUID LDAP attribute: uid
    User object classes: organizationalPerson
    User LDAP filter: "" (Can be used to select a subset of LDAP users to federate)
    Search scope: Subtree
    Pagination: Yes

SAML connections
================
[ ] Migrate jumpcloud-saml


tom-test team
================
[ ] Create a group in the cloudpak realm called tom-test-admins
[ ] Add user/s Victoria to tom-test-admins group
[ ] Assign admin role mapping (from integration-cp4i-jbmbm) to tom-test-admins group



Finished IAM migration helper script
```