### PR TITLE
fix: Escape group names when calling keycloak

### DIFF
--- a/iam-keycloak-migration.sh
+++ b/iam-keycloak-migration.sh
@@ -54,6 +54,42 @@ keycloakCloudPakRealm="cloudpak"
 checkAgainstKeycloak="true"
 
 ### Functions
+# Url encode a string
+function url_encode() {
+    echo "$@" \
+    | sed \
+        -e 's/%/%25/g' \
+        -e 's/ /%20/g' \
+        -e 's/!/%21/g' \
+        -e 's/"/%22/g' \
+        -e "s/'/%27/g" \
+        -e 's/#/%23/g' \
+        -e 's/(/%28/g' \
+        -e 's/)/%29/g' \
+        -e 's/+/%2b/g' \
+        -e 's/,/%2c/g' \
+        -e 's/-/%2d/g' \
+        -e 's/:/%3a/g' \
+        -e 's/;/%3b/g' \
+        -e 's/?/%3f/g' \
+        -e 's/@/%40/g' \
+        -e 's/\$/%24/g' \
+        -e 's/\&/%26/g' \
+        -e 's/\*/%2a/g' \
+        -e 's/\./%2e/g' \
+        -e 's/\//%2f/g' \
+        -e 's/\[/%5b/g' \
+        -e 's/\\/%5c/g' \
+        -e 's/\]/%5d/g' \
+        -e 's/\^/%5e/g' \
+        -e 's/_/%5f/g' \
+        -e 's/`/%60/g' \
+        -e 's/{/%7b/g' \
+        -e 's/|/%7c/g' \
+        -e 's/}/%7d/g' \
+        -e 's/~/%7e/g'
+}
+
 # Get an access token
 function getCsAccessToken {
     echo ""
@@ -407,7 +443,8 @@ function inspectIdpConnections {
 }
 
 function getKeycloakGroup() {
-  keycloakGroups="$(curl -ks "https://$keycloakUrl/admin/realms/$keycloakCloudPakRealm/groups?search=$1&exact=true" \
+  groupNameEscaped=$(url_encode $1)
+  keycloakGroups="$(curl -ks "https://$keycloakUrl/admin/realms/$keycloakCloudPakRealm/groups?search=$groupNameEscaped&exact=true" \
   --header "Authorization: Bearer $keycloakAccessToken")"
 
   # Check we have not got an error

--- a/iam-keycloak-migration.sh
+++ b/iam-keycloak-migration.sh
@@ -54,42 +54,6 @@ keycloakCloudPakRealm="cloudpak"
 checkAgainstKeycloak="true"
 
 ### Functions
-# Url encode a string
-function url_encode() {
-    echo "$@" \
-    | sed \
-        -e 's/%/%25/g' \
-        -e 's/ /%20/g' \
-        -e 's/!/%21/g' \
-        -e 's/"/%22/g' \
-        -e "s/'/%27/g" \
-        -e 's/#/%23/g' \
-        -e 's/(/%28/g' \
-        -e 's/)/%29/g' \
-        -e 's/+/%2b/g' \
-        -e 's/,/%2c/g' \
-        -e 's/-/%2d/g' \
-        -e 's/:/%3a/g' \
-        -e 's/;/%3b/g' \
-        -e 's/?/%3f/g' \
-        -e 's/@/%40/g' \
-        -e 's/\$/%24/g' \
-        -e 's/\&/%26/g' \
-        -e 's/\*/%2a/g' \
-        -e 's/\./%2e/g' \
-        -e 's/\//%2f/g' \
-        -e 's/\[/%5b/g' \
-        -e 's/\\/%5c/g' \
-        -e 's/\]/%5d/g' \
-        -e 's/\^/%5e/g' \
-        -e 's/_/%5f/g' \
-        -e 's/`/%60/g' \
-        -e 's/{/%7b/g' \
-        -e 's/|/%7c/g' \
-        -e 's/}/%7d/g' \
-        -e 's/~/%7e/g'
-}
-
 # Get an access token
 function getCsAccessToken {
     echo ""
@@ -443,8 +407,7 @@ function inspectIdpConnections {
 }
 
 function getKeycloakGroup() {
-  groupNameEscaped=$(url_encode $1)
-  keycloakGroups="$(curl -ks "https://$keycloakUrl/admin/realms/$keycloakCloudPakRealm/groups?search=$groupNameEscaped&exact=true" \
+  keycloakGroups="$(curl -ks --get "https://$keycloakUrl/admin/realms/$keycloakCloudPakRealm/groups" --data-urlencode "search=$1&exact=true" \
   --header "Authorization: Bearer $keycloakAccessToken")"
 
   # Check we have not got an error


### PR DESCRIPTION
As per title - otherwise groups such as `Devops engineers (test)` fails when calling keycloak